### PR TITLE
유보라 / iamyubora@gmail.com / 백엔드 과제 수행

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,3 +31,7 @@ dependencies {
     testImplementation 'org.springframework.security:spring-security-test'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }
+
+tasks.named('test') {
+    useJUnitPlatform()
+}

--- a/src/main/java/antigravity/controller/ProductController.java
+++ b/src/main/java/antigravity/controller/ProductController.java
@@ -27,10 +27,10 @@ public class ProductController {
     }
 
     private ProductInfoRequest getParam() {
-        int[] couponIds = {1, 2};
+        long[] couponIds = {1L, 2L};
 
         ProductInfoRequest request = ProductInfoRequest.builder()
-                .productId(1)
+                .productId(1L)
                 .couponIds(couponIds)
                 .build();
 

--- a/src/main/java/antigravity/domain/entity/Product.java
+++ b/src/main/java/antigravity/domain/entity/Product.java
@@ -1,12 +1,29 @@
 package antigravity.domain.entity;
 
 import lombok.Builder;
-import lombok.Data;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
-@Data
-@Builder
+import javax.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
+
+@NoArgsConstructor
+@Getter
+@Entity
 public class Product {
-    private int id;
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
     private String name;
     private int price;
+
+    @OneToMany(mappedBy = "product", cascade = CascadeType.ALL)
+    private List<PromotionProducts> promotionProducts = new ArrayList<>();
+
+    @Builder
+    public Product(String name, int price) {
+        this.name = name;
+        this.price = price;
+    }
 }

--- a/src/main/java/antigravity/domain/entity/Product.java
+++ b/src/main/java/antigravity/domain/entity/Product.java
@@ -18,9 +18,6 @@ public class Product {
     private String name;
     private int price;
 
-    @OneToMany(mappedBy = "product", cascade = CascadeType.ALL)
-    private List<PromotionProducts> promotionProducts = new ArrayList<>();
-
     @Builder
     public Product(String name, int price) {
         this.name = name;

--- a/src/main/java/antigravity/domain/entity/Promotion.java
+++ b/src/main/java/antigravity/domain/entity/Promotion.java
@@ -1,16 +1,21 @@
 package antigravity.domain.entity;
 
 import lombok.Builder;
-import lombok.Data;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
-import javax.persistence.EnumType;
-import javax.persistence.Enumerated;
+import javax.persistence.*;
+import java.util.ArrayList;
 import java.util.Date;
+import java.util.List;
 
-@Data
-@Builder
+@NoArgsConstructor
+@Getter
+@Entity
 public class Promotion {
-    private int id;
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
     @Enumerated(EnumType.STRING)
     private PromotionType promotion_type; //쿠폰 타입 (쿠폰, 코드)
     private String name;
@@ -18,4 +23,17 @@ public class Promotion {
     private int discount_value; // 할인 금액 or 할인 %
     private Date use_started_at; // 쿠폰 사용가능 시작 기간
     private Date use_ended_at; // 쿠폰 사용가능 종료 기간
+
+    @OneToMany(mappedBy = "promotion", cascade = CascadeType.ALL)
+    private List<PromotionProducts> promotionProducts = new ArrayList<>();
+
+    @Builder
+    public Promotion(PromotionType promotion_type, String name, String discount_type, int discount_value, Date use_started_at, Date use_ended_at) {
+        this.promotion_type = promotion_type;
+        this.name = name;
+        this.discount_type = discount_type;
+        this.discount_value = discount_value;
+        this.use_started_at = use_started_at;
+        this.use_ended_at = use_ended_at;
+    }
 }

--- a/src/main/java/antigravity/domain/entity/Promotion.java
+++ b/src/main/java/antigravity/domain/entity/Promotion.java
@@ -24,9 +24,6 @@ public class Promotion {
     private Date use_started_at; // 쿠폰 사용가능 시작 기간
     private Date use_ended_at; // 쿠폰 사용가능 종료 기간
 
-    @OneToMany(mappedBy = "promotion", cascade = CascadeType.ALL)
-    private List<PromotionProducts> promotionProducts = new ArrayList<>();
-
     @Builder
     public Promotion(PromotionType promotion_type, String name, String discount_type, int discount_value, Date use_started_at, Date use_ended_at) {
         this.promotion_type = promotion_type;

--- a/src/main/java/antigravity/domain/entity/Promotion.java
+++ b/src/main/java/antigravity/domain/entity/Promotion.java
@@ -3,13 +3,16 @@ package antigravity.domain.entity;
 import lombok.Builder;
 import lombok.Data;
 
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
 import java.util.Date;
 
 @Data
 @Builder
 public class Promotion {
     private int id;
-    private String promotion_type; //쿠폰 타입 (쿠폰, 코드)
+    @Enumerated(EnumType.STRING)
+    private PromotionType promotion_type; //쿠폰 타입 (쿠폰, 코드)
     private String name;
     private String discount_type; // WON : 금액 할인, PERCENT : %할인
     private int discount_value; // 할인 금액 or 할인 %

--- a/src/main/java/antigravity/domain/entity/PromotionProducts.java
+++ b/src/main/java/antigravity/domain/entity/PromotionProducts.java
@@ -1,12 +1,30 @@
 package antigravity.domain.entity;
 
 import lombok.Builder;
-import lombok.Data;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
-@Data
-@Builder
+import javax.persistence.*;
+
+@NoArgsConstructor
+@Getter
+@Entity
 public class PromotionProducts {
-    private int id;
-    private int promotionId;
-    private int productId;
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "promotion_id")
+    private Promotion promotion;
+
+    @ManyToOne
+    @JoinColumn(name = "product_id")
+    private Product product;
+
+    @Builder
+    public PromotionProducts(Promotion promotion, Product product) {
+        this.promotion = promotion;
+        this.product = product;
+    }
 }

--- a/src/main/java/antigravity/domain/entity/PromotionType.java
+++ b/src/main/java/antigravity/domain/entity/PromotionType.java
@@ -1,0 +1,6 @@
+package antigravity.domain.entity;
+
+public enum PromotionType {
+    COUPON,
+    CODE
+}

--- a/src/main/java/antigravity/model/request/ProductInfoRequest.java
+++ b/src/main/java/antigravity/model/request/ProductInfoRequest.java
@@ -6,6 +6,6 @@ import lombok.Data;
 @Data
 @Builder
 public class ProductInfoRequest {
-    private int productId;
-    private int[] couponIds;
+    private Long productId;
+    private long[] couponIds;
 }

--- a/src/main/java/antigravity/model/response/ProductAmountResponse.java
+++ b/src/main/java/antigravity/model/response/ProductAmountResponse.java
@@ -11,4 +11,9 @@ public class ProductAmountResponse {
     private int originPrice; //상품 기존 가격
     private int discountPrice; //총 할인 금액
     private int finalPrice; //확정 상품 가격
+
+    public int getFinalPrice() {
+        // 천 단위 절삭
+        return (this.finalPrice / 1000) * 1000;
+    }
 }

--- a/src/main/java/antigravity/repository/ProductRepository.java
+++ b/src/main/java/antigravity/repository/ProductRepository.java
@@ -1,30 +1,7 @@
 package antigravity.repository;
 
 import antigravity.domain.entity.Product;
-import lombok.RequiredArgsConstructor;
-import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
-import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
-import org.springframework.stereotype.Repository;
+import org.springframework.data.jpa.repository.JpaRepository;
 
-@RequiredArgsConstructor
-@Repository
-public class ProductRepository {
-    private final NamedParameterJdbcTemplate namedParameterJdbcTemplate;
-
-    public Product getProduct(int id) {
-        String query = "SELECT * FROM `product` WHERE id = :id ";
-
-        MapSqlParameterSource params = new MapSqlParameterSource();
-        params.addValue("id", id);
-
-        return namedParameterJdbcTemplate.queryForObject(
-                query,
-                params,
-                (rs, rowNum) -> Product.builder()
-                        .id(rs.getInt("id"))
-                        .name(rs.getString("name"))
-                        .price(rs.getInt("price"))
-                        .build()
-        );
-    }
+public interface ProductRepository extends JpaRepository<Product, Long> {
 }

--- a/src/main/java/antigravity/repository/PromotionProductsRepository.java
+++ b/src/main/java/antigravity/repository/PromotionProductsRepository.java
@@ -1,0 +1,12 @@
+package antigravity.repository;
+
+import antigravity.domain.entity.PromotionProducts;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
+
+public interface PromotionProductsRepository extends JpaRepository<PromotionProducts, Long> {
+    @Query("SELECT pp FROM PromotionProducts pp JOIN pp.promotion WHERE pp.product.id = :productId AND NOW() BETWEEN pp.promotion.use_started_at AND pp.promotion.use_ended_at")
+    List<PromotionProducts> findValidByProductId(Long productId);
+}

--- a/src/main/java/antigravity/repository/PromotionRepository.java
+++ b/src/main/java/antigravity/repository/PromotionRepository.java
@@ -1,0 +1,31 @@
+package antigravity.repository;
+
+import antigravity.domain.entity.Promotion;
+import antigravity.domain.entity.PromotionType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+@RequiredArgsConstructor
+@Repository
+public class PromotionRepository {
+    private final NamedParameterJdbcTemplate namedParameterJdbcTemplate;
+
+    public Promotion getPromotion(int id) {
+        String query = "SELECT * FROM `promotion` WHERE id = :id";
+
+        MapSqlParameterSource params = new MapSqlParameterSource();
+        params.addValue("id", id);
+
+        return namedParameterJdbcTemplate.queryForObject(
+                query,
+                params,
+                (rs, rowNum) -> Promotion.builder()
+                        .id(rs.getInt("id"))
+                        .promotion_type(PromotionType.valueOf(rs.getString("promotion_type")))
+                        .discount_value(rs.getInt("discount_value"))
+                        .build()
+        );
+    }
+}

--- a/src/main/java/antigravity/repository/PromotionRepository.java
+++ b/src/main/java/antigravity/repository/PromotionRepository.java
@@ -1,31 +1,7 @@
 package antigravity.repository;
 
 import antigravity.domain.entity.Promotion;
-import antigravity.domain.entity.PromotionType;
-import lombok.RequiredArgsConstructor;
-import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
-import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
-import org.springframework.stereotype.Repository;
+import org.springframework.data.jpa.repository.JpaRepository;
 
-@RequiredArgsConstructor
-@Repository
-public class PromotionRepository {
-    private final NamedParameterJdbcTemplate namedParameterJdbcTemplate;
-
-    public Promotion getPromotion(int id) {
-        String query = "SELECT * FROM `promotion` WHERE id = :id";
-
-        MapSqlParameterSource params = new MapSqlParameterSource();
-        params.addValue("id", id);
-
-        return namedParameterJdbcTemplate.queryForObject(
-                query,
-                params,
-                (rs, rowNum) -> Promotion.builder()
-                        .id(rs.getInt("id"))
-                        .promotion_type(PromotionType.valueOf(rs.getString("promotion_type")))
-                        .discount_value(rs.getInt("discount_value"))
-                        .build()
-        );
-    }
+public interface PromotionRepository extends JpaRepository<Promotion, Long> {
 }

--- a/src/main/java/antigravity/service/ProductService.java
+++ b/src/main/java/antigravity/service/ProductService.java
@@ -21,7 +21,7 @@ public class ProductService {
     private final PromotionProductsRepository promotionProductsRepository;
 
     @Transactional(readOnly = true)
-    public ProductAmountResponse getProductAmount(ProductInfoRequest request) throws IllegalArgumentException {
+    public ProductAmountResponse getProductAmount(ProductInfoRequest request) {
         System.out.println("상품 가격 추출 로직을 완성 시켜주세요.");
 
         Product product = productRepository.findById(request.getProductId()).orElseThrow();

--- a/src/main/java/antigravity/service/ProductService.java
+++ b/src/main/java/antigravity/service/ProductService.java
@@ -1,22 +1,56 @@
 package antigravity.service;
 
 import antigravity.domain.entity.Product;
+import antigravity.domain.entity.Promotion;
+import antigravity.domain.entity.PromotionType;
 import antigravity.model.request.ProductInfoRequest;
 import antigravity.model.response.ProductAmountResponse;
 import antigravity.repository.ProductRepository;
+import antigravity.repository.PromotionRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 @RequiredArgsConstructor
 @Service
 public class ProductService {
-    private final ProductRepository repository;
+    private final ProductRepository productRepository;
+    private final PromotionRepository promotionRepository;
 
     public ProductAmountResponse getProductAmount(ProductInfoRequest request) {
         System.out.println("상품 가격 추출 로직을 완성 시켜주세요.");
 
-        Product product = repository.getProduct(request.getProductId());
+        Product product = productRepository.getProduct(request.getProductId());
 
-        return null;
+        // 총 할인 가격 조회
+        int discountPrice = 0;
+        for (int couponId : request.getCouponIds()) {
+            Promotion promotion = getPromotion(couponId);
+            discountPrice += getDiscountPrice(product, promotion);
+        }
+
+        return ProductAmountResponse.builder()
+                .name(product.getName())
+                .originPrice(product.getPrice())
+                .discountPrice(discountPrice)
+                .finalPrice(product.getPrice() - discountPrice)
+                .build();
+    }
+
+    public Promotion getPromotion(int id) {
+        return promotionRepository.getPromotion(id);
+    }
+
+    /**
+     * 프로모션 타입별 최종 할인 금액 조회
+     * PromotionType.COUPON: discount_value 반환
+     * PromotionType.CODE: 상품 정상가의 discount_value(%) 가격 환산하여 반환
+     */
+    public int getDiscountPrice(Product product, Promotion promotion) {
+        PromotionType promotionType = promotion.getPromotion_type();
+        if (promotionType == PromotionType.CODE) {
+            double percent = promotion.getDiscount_value() / 100.00;
+            return (int) (product.getPrice() * percent);
+        }
+        return promotion.getDiscount_value();
     }
 }

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -23,3 +23,11 @@ spring:
       schema-locations: classpath*:/${database}/schema.sql
       data-locations: classpath*:/${database}/data.sql
       platform: h2
+
+  jpa:
+    hibernate:
+      ddl-auto: none
+    properties:
+      hibernate:
+        format_sql: true
+        show_sql: true

--- a/src/main/resources/hsqldb/schema.sql
+++ b/src/main/resources/hsqldb/schema.sql
@@ -2,7 +2,7 @@ DROP TABLE product IF EXISTS;
 
 CREATE TABLE product
 (
-    id    INTEGER NOT NULL,
+    id    INTEGER NOT NULL AUTO_INCREMENT,
     name  VARCHAR(255),
     price INTEGER,
     PRIMARY KEY (id)
@@ -12,7 +12,7 @@ DROP TABLE promotion IF EXISTS;
 
 CREATE TABLE promotion
 (
-    id             INTEGER NOT NULL,
+    id             INTEGER NOT NULL AUTO_INCREMENT,
     promotion_type VARCHAR(10),
     name           VARCHAR(255),
     discount_type  VARCHAR(15),
@@ -27,7 +27,7 @@ DROP TABLE promotion_products IF EXISTS;
 
 CREATE TABLE promotion_products
 (
-    id           INTEGER NOT NULL,
+    id           INTEGER NOT NULL AUTO_INCREMENT,
     promotion_id INTEGER,
     product_id   INTEGER,
     PRIMARY KEY (id)

--- a/src/test/java/antigravity/service/ProductServiceTest.java
+++ b/src/test/java/antigravity/service/ProductServiceTest.java
@@ -35,10 +35,6 @@ class ProductServiceTest {
     @Autowired
     PromotionProductsRepository promotionProductsRepository;
 
-    SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-dd");
-    Date use_started_at;
-    Date use_ended_at;
-
     @BeforeEach
     void clean() {
         productRepository.deleteAll();
@@ -136,8 +132,9 @@ class ProductServiceTest {
                 .build());
 
         // 쿠폰 세팅
-        use_started_at = formatter.parse("2023-03-01");
-        use_ended_at = formatter.parse(endDt);
+        SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-dd");
+        Date use_started_at = formatter.parse("2023-03-01");
+        Date use_ended_at = formatter.parse(endDt);
 
         List<Promotion> promotions = promotionRepository.saveAll(List.of(
                 Promotion.builder()

--- a/src/test/java/antigravity/service/ProductServiceTest.java
+++ b/src/test/java/antigravity/service/ProductServiceTest.java
@@ -39,7 +39,6 @@ class ProductServiceTest {
     void clean() {
         productRepository.deleteAll();
         promotionRepository.deleteAll();
-        promotionProductsRepository.deleteAll();
     }
 
     @Test

--- a/src/test/java/antigravity/service/ProductServiceTest.java
+++ b/src/test/java/antigravity/service/ProductServiceTest.java
@@ -1,12 +1,107 @@
 package antigravity.service;
 
+import antigravity.domain.entity.Product;
+import antigravity.domain.entity.Promotion;
+import antigravity.domain.entity.PromotionType;
+import antigravity.model.request.ProductInfoRequest;
+import antigravity.model.response.ProductAmountResponse;
+import antigravity.repository.ProductRepository;
+import antigravity.repository.PromotionRepository;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 
+@SpringBootTest
 class ProductServiceTest {
 
+    @Autowired
+    ProductService productService;
+    @Autowired
+    ProductRepository productRepository;
+    @Autowired
+    PromotionRepository promotionRepository;
+
     @Test
-    void getProductAmount() {
-        System.out.println("상품 가격 추출 테스트");
+    @DisplayName("상품 쿠폰 적용 정상")
+    void getProductAmountTest() {
+        // given
+        int[] couponIds = {1, 2};
+        ProductInfoRequest request = ProductInfoRequest.builder()
+                .productId(1)
+                .couponIds(couponIds)
+                .build();
+
+        Product product = productRepository.getProduct(request.getProductId());
+
+        List<Promotion> promotions = new ArrayList<>();
+        for (int id : couponIds) {
+            promotions.add(promotionRepository.getPromotion(id));
+        }
+
+        // when
+        ProductAmountResponse result = productService.getProductAmount(request);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.getOriginPrice()).isEqualTo(product.getPrice());
+        assertThat(result.getDiscountPrice())
+                .isEqualTo(promotions.stream()
+                        .mapToInt(promotion -> productService.getDiscountPrice(product, promotion))
+                        .sum());
+    }
+
+    @Test
+    @DisplayName("promotion 조회 정상")
+    void getPromotionTest() {
+        // given & when
+        Promotion result = productService.getPromotion(1);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.getId()).isEqualTo(1);
+        assertThat(result.getPromotion_type()).isEqualTo(PromotionType.COUPON);
+        assertThat(result.getDiscount_value()).isEqualTo(30000);
+    }
+
+    @Test
+    @DisplayName("할인 가격 조회 정상")
+    void getDiscountPriceTest() {
+        // given
+        int[] couponIds = {1, 2};
+        ProductInfoRequest request = ProductInfoRequest.builder()
+                .productId(1)
+                .couponIds(couponIds)
+                .build();
+
+        Product product = productRepository.getProduct(request.getProductId());
+        List<Promotion> promotions = new ArrayList<>();
+        for (int id : couponIds) {
+            promotions.add(promotionRepository.getPromotion(id));
+        }
+
+        for (Promotion promotion : promotions) {
+            // when
+            int result = productService.getDiscountPrice(product, promotion);
+
+            //then
+            assertPrice(promotion, product, result);
+        }
+    }
+
+    private void assertPrice(Promotion promotion, Product product, double expectedPrice) {
+        PromotionType promotionType = promotion.getPromotion_type();
+
+        if (promotionType.equals(PromotionType.CODE)) {
+            assertThat(expectedPrice).isEqualTo(product.getPrice() * promotion.getDiscount_value() / 100.00);
+        } else {
+            assertThat(expectedPrice).isEqualTo(promotion.getDiscount_value());
+        }
     }
 }

--- a/src/test/java/antigravity/service/ProductServiceTest.java
+++ b/src/test/java/antigravity/service/ProductServiceTest.java
@@ -2,17 +2,22 @@ package antigravity.service;
 
 import antigravity.domain.entity.Product;
 import antigravity.domain.entity.Promotion;
+import antigravity.domain.entity.PromotionProducts;
 import antigravity.domain.entity.PromotionType;
 import antigravity.model.request.ProductInfoRequest;
 import antigravity.model.response.ProductAmountResponse;
 import antigravity.repository.ProductRepository;
+import antigravity.repository.PromotionProductsRepository;
 import antigravity.repository.PromotionRepository;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
-import java.util.ArrayList;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -27,23 +32,33 @@ class ProductServiceTest {
     ProductRepository productRepository;
     @Autowired
     PromotionRepository promotionRepository;
+    @Autowired
+    PromotionProductsRepository promotionProductsRepository;
+
+    SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-dd");
+    Date use_started_at;
+    Date use_ended_at;
+
+    @BeforeEach
+    void clean() {
+        productRepository.deleteAll();
+        promotionRepository.deleteAll();
+        promotionProductsRepository.deleteAll();
+    }
 
     @Test
     @DisplayName("상품 쿠폰 적용 정상")
-    void getProductAmountTest() {
+    void getProductAmountTest() throws ParseException {
         // given
-        int[] couponIds = {1, 2};
+        createFixture("2024-03-31");
+        Product product = productRepository.findAll().get(0);
+        List<PromotionProducts> promotionProducts = promotionProductsRepository.findValidByProductId(product.getId());
+        long[] couponIds = promotionProducts.stream().mapToLong(pp -> pp.getPromotion().getId()).toArray();
+
         ProductInfoRequest request = ProductInfoRequest.builder()
-                .productId(1)
+                .productId(product.getId())
                 .couponIds(couponIds)
                 .build();
-
-        Product product = productRepository.getProduct(request.getProductId());
-
-        List<Promotion> promotions = new ArrayList<>();
-        for (int id : couponIds) {
-            promotions.add(promotionRepository.getPromotion(id));
-        }
 
         // when
         ProductAmountResponse result = productService.getProductAmount(request);
@@ -52,39 +67,45 @@ class ProductServiceTest {
         assertThat(result).isNotNull();
         assertThat(result.getOriginPrice()).isEqualTo(product.getPrice());
         assertThat(result.getDiscountPrice())
-                .isEqualTo(promotions.stream()
-                        .mapToInt(promotion -> productService.getDiscountPrice(product, promotion))
+                .isEqualTo(promotionProducts.stream()
+                        .mapToInt(pp -> productService.getDiscountPrice(pp.getProduct(), pp.getPromotion()))
                         .sum());
+        assertThat(result.getFinalPrice())
+                .isEqualTo(cutOffPrice(result.getOriginPrice() - result.getDiscountPrice()));
     }
 
     @Test
-    @DisplayName("promotion 조회 정상")
-    void getPromotionTest() {
-        // given & when
-        Promotion result = productService.getPromotion(1);
+    @DisplayName("적용 가능한 쿠폰이 없으면 할인 가격 0원")
+    void getProductAmountTest2() throws ParseException {
+        // given
+        createFixture("2023-03-02"); // 기한 만료
+        Product product = productRepository.findAll().get(0);
+        List<PromotionProducts> promotionProducts = promotionProductsRepository.findValidByProductId(product.getId());
+        long[] couponIds = promotionProducts.stream().mapToLong(pp -> pp.getPromotion().getId()).toArray();
+
+        ProductInfoRequest request = ProductInfoRequest.builder()
+                .productId(product.getId())
+                .couponIds(couponIds)
+                .build();
+
+        // when
+        ProductAmountResponse result = productService.getProductAmount(request);
 
         // then
         assertThat(result).isNotNull();
-        assertThat(result.getId()).isEqualTo(1);
-        assertThat(result.getPromotion_type()).isEqualTo(PromotionType.COUPON);
-        assertThat(result.getDiscount_value()).isEqualTo(30000);
+        assertThat(result.getOriginPrice()).isEqualTo(product.getPrice());
+        assertThat(result.getDiscountPrice()).isEqualTo(0);
+        assertThat(result.getFinalPrice())
+                .isEqualTo(cutOffPrice(result.getOriginPrice()));
     }
 
     @Test
     @DisplayName("할인 가격 조회 정상")
-    void getDiscountPriceTest() {
+    void getDiscountPriceTest() throws ParseException {
         // given
-        int[] couponIds = {1, 2};
-        ProductInfoRequest request = ProductInfoRequest.builder()
-                .productId(1)
-                .couponIds(couponIds)
-                .build();
-
-        Product product = productRepository.getProduct(request.getProductId());
-        List<Promotion> promotions = new ArrayList<>();
-        for (int id : couponIds) {
-            promotions.add(promotionRepository.getPromotion(id));
-        }
+        createFixture("2024-03-31");
+        List<Promotion> promotions = promotionRepository.findAll();
+        Product product = productRepository.findAll().get(0);
 
         for (Promotion promotion : promotions) {
             // when
@@ -95,13 +116,65 @@ class ProductServiceTest {
         }
     }
 
-    private void assertPrice(Promotion promotion, Product product, double expectedPrice) {
+    private void assertPrice(Promotion promotion, Product product, int expectedPrice) {
         PromotionType promotionType = promotion.getPromotion_type();
 
         if (promotionType.equals(PromotionType.CODE)) {
-            assertThat(expectedPrice).isEqualTo(product.getPrice() * promotion.getDiscount_value() / 100.00);
+            assertThat(expectedPrice).isEqualTo((int) (product.getPrice() * (promotion.getDiscount_value() / 100.00)));
         } else {
             assertThat(expectedPrice).isEqualTo(promotion.getDiscount_value());
         }
+    }
+
+    private void createFixture(String endDt) throws ParseException {
+        System.out.println("#### FIXTURE ####");
+
+        // 상품 세팅
+        Product product = productRepository.save(Product.builder()
+                .name("테스트 상품")
+                .price(254900)
+                .build());
+
+        // 쿠폰 세팅
+        use_started_at = formatter.parse("2023-03-01");
+        use_ended_at = formatter.parse(endDt);
+
+        List<Promotion> promotions = promotionRepository.saveAll(List.of(
+                Promotion.builder()
+                        .promotion_type(PromotionType.COUPON)
+                        .name("5000원 할인쿠폰")
+                        .discount_type("WON")
+                        .discount_value(5000)
+                        .use_started_at(use_started_at)
+                        .use_ended_at(use_ended_at)
+                        .build(),
+
+                Promotion.builder()
+                        .promotion_type(PromotionType.CODE)
+                        .name("10% 할인코드")
+                        .discount_type("PERCENT")
+                        .discount_value(10)
+                        .use_started_at(use_started_at)
+                        .use_ended_at(use_ended_at)
+                        .build()
+        ));
+
+        // 매핑 정보 세팅
+        promotionProductsRepository.saveAll(List.of(
+                PromotionProducts.builder()
+                        .product(product)
+                        .promotion(promotions.get(0))
+                        .build(),
+
+                PromotionProducts.builder()
+                        .product(product)
+                        .promotion(promotions.get(1))
+                        .build()
+        ));
+    }
+
+    private int cutOffPrice(int price) {
+        // 천 단위 절사
+        return (price / 1000) * 1000;
     }
 }


### PR DESCRIPTION
[[getProductAmount 구현](https://github.com/antigravity-official/backend-product-amount/commit/f97244a3d9824ee5b40ab9e967242f71e3f9f490)]
- 요구사항에 따른 비즈니스 로직을 1차적으로 작성했습니다.

[[Test 코드 추가](https://github.com/antigravity-official/backend-product-amount/commit/cf3da80dd7bea39dfa99ae85c37faa2d8b3935b4)]
- `ProductService`에 작성된 메서드의 테스트 코드를 작성했습니다.

[[jpa 적용, test 코드 수정](https://github.com/antigravity-official/backend-product-amount/commit/70b3f4522289b899213a01c8c11479a832582815)]
- 제공받은 데이터에 현재 사용 가능한 프로모션이 없어 정확한 테스트가 어렵다고 판단했습니다.
- 때문에 테스트 코드에서 fixture를 편하게 생성하기 위헤 JdbcTemplate 대신 JPA를 적용했습니다.
- `promotion_products` 테이블에서 가격을 산출할 상품이 매핑된 프로모션 중 유효한 프로모션만 조회하여 가격을 계산합니다.

[[양방향 -> 단방향](https://github.com/antigravity-official/backend-product-amount/commit/35e652a5232e3d9439eb5ecd94035e0b7d5e8f90)]
- `promotion_products` entity에서 `@ManyToOne` 관계 만으로도 원하는 데이터를 충분히 조회할 수 있어 양방향 관계를 단방향으로 수정하였습니다.

